### PR TITLE
Fix inference server could not start up correctly.

### DIFF
--- a/fish_speech/webui/manage.py
+++ b/fish_speech/webui/manage.py
@@ -101,7 +101,7 @@ def change_infer(if_infer, host, port, backend_host, backend_port):
     global p_infer
     if if_infer == True and p_infer == None:
         env = os.environ.copy()
-        subprocess.Popen(["uvicorn", "tools.stream_server:app",
+        subprocess.Popen([PYTHON, "-m", "uvicorn", "tools.stream_server:app",
                           "--host", f"{backend_host}", "--port", f"{backend_port}"], env=env)
 
         env["GRADIO_SERVER_NAME"] = host


### PR DESCRIPTION
**Is this PR adding new feature or fix a BUG?**

- Fix BUG.

**Is this pull request related to any issue? If yes, please link the issue.**

#xxx

By calling uvicorn directly, issue happened on by side. The inference server server failed to start and return `Fatal error in launcher: Unable to create process using '"D:\miniconda\envs\fish\python.exe"  "C:\Users\Naozumi0512\Downloads\fish-speech-0.4\fish-speech\vits\Scripts\uvicorn.exe" tools.stream_server:app --host 127.0.0.1 --port 8000': The system cannot find the file specified.`

It seemed like a wrong python exe was being used by here. Since I have no D drive, `D:\miniconda\envs\fish\python.exe` is nonsense. By calling uvicorn with -m flag on PYTHON ensure that the correct python exe in your pack is being used, and solved this issue w/o affecting other users.